### PR TITLE
Fixed README and Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ wrap for **socks5-http-client** and **socks5-https-client**. I wrote this becaus
 const axios = require('axios')
 const SocksAgent = require('axios-socks5-agent')
 
-const { httpAgent, httpsAgent } = new SocksAgent({
+const { httpAgent, httpsAgent } = SocksAgent({
   agentOptions: {
     keepAlive: true,
   },

--- a/index.ts
+++ b/index.ts
@@ -14,7 +14,7 @@ import { Socks5AgentOptions } from './types/axios-socks5-agent'
  * @param {AxiosSocks5AgentOptions} options
  * @return { { httpAgent: Agent, httpsAgent: Agent } }
  */
-function Socks5Agent(options: Socks5AgentOptions): {httpAgent: HttpAgent, httpsAgent: HttpsAgent} {
+function Socks5Agent(options: Socks5AgentOptions): {httpAgent: any, httpsAgent: any} {
   const {
     host = '127.0.0.1',
     port = 9050,


### PR DESCRIPTION
* Fixed README as SocksAgent is not a constructor.
* Fixed return types of `Socks5Agent`. Before fix tsc refused to build with:
```
node_modules/axios-socks5-agent/index.d.ts:5:16 - error TS2709: Cannot use namespace 'HttpAgent' as a type.
5     httpAgent: HttpAgent;
                 ~~~~~~~~~
node_modules/axios-socks5-agent/index.d.ts:6:17 - error TS2709: Cannot use namespace 'HttpsAgent' as a type.
6     httpsAgent: HttpsAgent;
                  ~~~~~~~~~~
```
Note: Axios uses `any` for [httpAgent & httpsAgent](https://github.com/axios/axios/blob/6b4fd93e6886c281ef1a51fca556616ce17f8fba/index.d.ts#L87) anyway.